### PR TITLE
Guard local averaging for Adasum with nccl_built()

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -97,8 +97,8 @@ def allreduce(tensor, average=None, device_dense='', device_sparse='',
                 # This behavior will interfere with any sessions created before or after. Also it's not stable in tf 2.0. Using nvidia-smi for now.
                 # Need to find a better way to replace this logic.
                 import subprocess
-                num_gpus = str(subprocess.check_output(["nvidia-smi", "-L"])).count('UUID')
-                if (num_gpus > 0 and 'CPU' not in tensor.device):
+                get_num_gpus = lambda: str(subprocess.check_output(["nvidia-smi", "-L"])).count('UUID')
+                if (nccl_built() and 'CPU' not in tensor.device and get_num_gpus() > 0):
                     horovod_local_size = tf.cast(local_size(), dtype=tensor.dtype)
                     new_tensor = summed_tensor / horovod_local_size
                 else:

--- a/horovod/torch/mpi_ops.py
+++ b/horovod/torch/mpi_ops.py
@@ -92,7 +92,7 @@ def _allreduce_async(tensor, output, name, op):
 
     if op == Average:
         divisor = size()
-    elif (op == Adasum and torch.cuda.is_available() and tensor.device.type != 'cpu'):
+    elif (op == Adasum and nccl_built() and tensor.device.type != 'cpu' and torch.cuda.is_available()):
         divisor = local_size()
     else:
         divisor = 1


### PR DESCRIPTION
Also move checks for if GPUs are available to the end of the checks, just in case those checks happen to be slow.

Has not been tested, so if someone has a machine please run a test of this.